### PR TITLE
Add gem paratrooper to ease heroku staging and production

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ gem 'pg'
 gem 'sidekiq'
 gem 'sinatra', require: false
 gem 'slim'
-
+gem 'paratrooper'
 
 group :development do
   gem 'thin'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -72,6 +72,7 @@ GEM
     diff-lcs (1.2.5)
     erubis (2.7.0)
     eventmachine (1.0.0)
+    excon (0.42.1)
     execjs (2.0.2)
     fabrication (2.11.3)
     faker (1.4.3)
@@ -85,6 +86,9 @@ GEM
       activesupport (>= 4.0.1)
       haml (>= 3.1, < 5.0)
       railties (>= 4.0.1)
+    heroku-api (0.3.22)
+      excon (~> 0.38)
+      multi_json (~> 1.8)
     hike (1.2.3)
     hirb (0.7.2)
     hitimes (1.2.2)
@@ -107,8 +111,14 @@ GEM
     minitest (5.3.4)
     multi_json (1.10.1)
     multipart-post (2.0.0)
+    netrc (0.10.2)
     nokogiri (1.6.5)
       mini_portile (~> 0.6.0)
+    paratrooper (2.4.1)
+      excon
+      heroku-api (~> 0.3)
+      netrc (~> 0.7)
+      rendezvous (~> 0.0.1)
     pg (0.17.0)
     polyglot (0.3.5)
     pry (0.9.12.3)
@@ -149,6 +159,7 @@ GEM
     redis (3.2.0)
     redis-namespace (1.5.1)
       redis (~> 3.0, >= 3.0.4)
+    rendezvous (0.0.2)
     rspec-collection_matchers (1.0.0)
       rspec-expectations (>= 2.99.0.beta1)
     rspec-core (2.99.0)
@@ -240,6 +251,7 @@ DEPENDENCIES
   jquery-rails
   launchy
   letter_opener
+  paratrooper
   pg
   pry
   pry-nav

--- a/lib/tasks/deploy.rake
+++ b/lib/tasks/deploy.rake
@@ -1,0 +1,20 @@
+require 'paratrooper'
+
+namespace :deploy do
+  desc 'Deploy app in staging environment'
+  task :staging do
+    deployment = Paratrooper::Deploy.new("tt-staging-myflix", tag: 'staging')
+
+    deployment.deploy
+  end
+
+  desc 'Deploy app in production environment'
+  task :production do
+    deployment = Paratrooper::Deploy.new("tt-myflix") do |deploy|
+      deploy.tag              = 'production'
+      deploy.match_tag        = 'staging'
+    end
+
+    deployment.deploy
+  end
+end


### PR DESCRIPTION
1) Add gem paratrooper to ease heroku staging and production
